### PR TITLE
Performance and style improvements.

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.emilsjolander.components.StickyListHeaders"
+    package="com.emilsjolander.components.stickylistheaders"
     android:versionCode="1"
     android:versionName="1.0" >
 
     <uses-sdk android:minSdkVersion="7" android:targetSdkVersion="15" />
-    
+
 </manifest>

--- a/library/res/values/ids.xml
+++ b/library/res/values/ids.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <item type="id" name="__stickylistheaders_header_view" />
-  <item type="id" name="__stickylistheaders_list_item_view" />
-  <item type="id" name="__stickylistheaders_list_view" />
-  <item type="id" name="__stickylistheaders_divider_view" />
-  <item type="id" name="__stickylistheaders_wrapper_view" />
-</resources>

--- a/library/src/com/emilsjolander/components/StickyListHeaders/StickyListHeadersAdapter.java
+++ b/library/src/com/emilsjolander/components/StickyListHeaders/StickyListHeadersAdapter.java
@@ -1,13 +1,14 @@
-package com.emilsjolander.components.StickyListHeaders;
+package com.emilsjolander.components.stickylistheaders;
 
 import android.graphics.drawable.Drawable;
 import android.view.View;
+import android.widget.ListAdapter;
 
-public interface StickyListHeadersAdapter {
-	public abstract View getHeaderView(int position, View convertView);
-	public abstract long getHeaderId(int position);
-	
-	public abstract void setDivider(Drawable divider, int dividerHeight);
-	public abstract void setDivider(Drawable divider);
-	public abstract void setDividerHeight(int dividerHeight);
+public interface StickyListHeadersAdapter extends ListAdapter {
+	View getHeaderView(int position, View convertView);
+	long getHeaderId(int position);
+
+	void setDivider(Drawable divider, int dividerHeight);
+	void setDivider(Drawable divider);
+	void setDividerHeight(int dividerHeight);
 }

--- a/library/src/com/emilsjolander/components/StickyListHeaders/StickyListHeadersCursorAdapter.java
+++ b/library/src/com/emilsjolander/components/StickyListHeaders/StickyListHeadersCursorAdapter.java
@@ -1,4 +1,4 @@
-package com.emilsjolander.components.StickyListHeaders;
+package com.emilsjolander.components.stickylistheaders;
 
 import java.util.ArrayList;
 
@@ -11,11 +11,13 @@ import android.view.ViewGroup;
 import android.widget.CursorAdapter;
 import android.widget.LinearLayout;
 
+import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+
 /**
- * 
+ *
  * @author Emil Sj�lander
- * 
- * 
+ *
+ *
 Copyright 2012 Emil Sj�lander
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,7 +54,7 @@ public abstract class StickyListHeadersCursorAdapter extends CursorAdapter imple
 	}
 
 	/**
-	 * 
+	 *
 	 * WARNING! will crash on api lvls pre 11
 	 */
 	@SuppressLint("NewApi")
@@ -60,7 +62,7 @@ public abstract class StickyListHeadersCursorAdapter extends CursorAdapter imple
 		super(context,c,flags);
 		setup(context);
 	}
-	
+
 	private void setup(Context context){
 		headerCache = new ArrayList<View>();
 		dividerCache = new ArrayList<View>();
@@ -69,7 +71,7 @@ public abstract class StickyListHeadersCursorAdapter extends CursorAdapter imple
 	}
 
 	/**
-	 * 
+	 *
 	 * @param position
 	 * list item's position in list, NOT the index of the header
 	 * @param convertView
@@ -109,7 +111,7 @@ public abstract class StickyListHeadersCursorAdapter extends CursorAdapter imple
 	protected abstract void bindHeaderView(View view, Context context, Cursor cursor);
 
 	/**
-	 * 
+	 *
 	 * @param position
 	 * the list position
 	 * @return
@@ -121,9 +123,9 @@ public abstract class StickyListHeadersCursorAdapter extends CursorAdapter imple
 		}
 		return getHeaderId(context,getCursor());
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @param context
 	 * Interface to application's global information
 	 * @param cursor
@@ -140,13 +142,11 @@ public abstract class StickyListHeadersCursorAdapter extends CursorAdapter imple
 			header = headerCache.remove(0);
 		}
 		header = getHeaderView(position,header);
-		header.setId(R.id.__stickylistheaders_header_view);
 		return header;
 	}
 
 	//attaches a header to a list item
 	private View attachHeaderToListItem(View header, View listItem){
-		listItem.setId(R.id.__stickylistheaders_list_item_view);
 		WrapperView wrapper = null;
 		if(wrapperCache.size()>0){
 			wrapper = wrapperCache.remove(0);
@@ -157,12 +157,11 @@ public abstract class StickyListHeadersCursorAdapter extends CursorAdapter imple
 		//this does so touches on header are not counted as listitem clicks
 		header.setClickable(true);
 		header.setFocusable(false);
-		return wrapper.wrapViews(header,listItem);
+		return wrapper.wrapViews(listItem, null, header);
 	}
 
 	//attaches a divider to list item
 	private View attachDividerToListItem(View listItem) {
-		listItem.setId(R.id.__stickylistheaders_list_item_view);
 		WrapperView wrapper = null;
 		if(wrapperCache.size()>0){
 			wrapper = wrapperCache.remove(0);
@@ -176,47 +175,44 @@ public abstract class StickyListHeadersCursorAdapter extends CursorAdapter imple
 		}
 		if(divider == null){
 			divider = new View(context);
-			divider.setId(R.id.__stickylistheaders_divider_view);
-			LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(-1, dividerHeight);
+			LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(MATCH_PARENT, dividerHeight);
 			divider.setLayoutParams(params);
 		}
 		divider.setBackgroundDrawable(this.divider);
-		return wrapper.wrapViews(divider,listItem);
+		return wrapper.wrapViews(listItem, divider, null);
 	}
 
 	//puts header into headerCache, wrapper into wrapperCache and returns listItem
 	//if convertView is null, returns null
-	private View axtractHeaderAndListItemFromConvertView(View convertView){
+	private View extractHeaderAndListItemFromConvertView(View convertView){
 		if(convertView == null) return null;
-		ViewGroup vg = (ViewGroup) convertView;
+		WrapperView wv = (WrapperView) convertView;
 
-		View header = vg.findViewById(R.id.__stickylistheaders_header_view);
+		View header = wv.getHeader();
 		if(header!=null){
 			header.setVisibility(View.VISIBLE);
 			headerCache.add(header);
 		}
 
-		View divider = vg.findViewById(R.id.__stickylistheaders_divider_view);
+		View divider = wv.getDivider();
 		if(divider!=null){
 			dividerCache.add(divider);
 		}
 
-		View listItem = vg.findViewById(R.id.__stickylistheaders_list_item_view);
-		vg.removeAllViews();
-		wrapperCache.add(new WrapperView(convertView));
+		View listItem = wv.getItem();
+		wv.removeAllViews();
+		wrapperCache.add(wv);
 
 		return listItem;
 	}
 
 	@Override
 	public View getView(int position, View convertView, ViewGroup parent) {
-		View v = super.getView(position,axtractHeaderAndListItemFromConvertView(convertView),parent);
+		View v = super.getView(position,extractHeaderAndListItemFromConvertView(convertView),parent);
 		if(position == 0 || getHeaderId(position)!=getHeaderId(position-1)){
 			v = attachHeaderToListItem(getHeaderForPosition(position),v);
-			v.setTag(true);
 		}else{
 			v = attachDividerToListItem(v);
-			v.setTag(false);
 		}
 		return v;
 	}
@@ -249,7 +245,7 @@ public abstract class StickyListHeadersCursorAdapter extends CursorAdapter imple
 	public void setDividerHeight(int dividerHeight) {
 		this.dividerHeight = dividerHeight;
 	}
-	
+
 	@Override
 	public void notifyDataSetChanged() {
 		wrapperCache.clear();

--- a/library/src/com/emilsjolander/components/StickyListHeaders/StickyListHeadersListView.java
+++ b/library/src/com/emilsjolander/components/StickyListHeaders/StickyListHeadersListView.java
@@ -1,4 +1,4 @@
-package com.emilsjolander.components.StickyListHeaders;
+package com.emilsjolander.components.stickylistheaders;
 
 import android.content.Context;
 import android.content.res.TypedArray;
@@ -18,10 +18,10 @@ import android.widget.AbsListView.OnScrollListener;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 /**
- * 
+ *
  * @author Emil Sj��lander
- * 
- * 
+ *
+ *
 Copyright 2012 Emil Sj��lander
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,10 +38,11 @@ limitations under the License.
  *
  */
 public class StickyListHeadersListView extends ListView implements OnScrollListener {
-	
+
+	private static final String TAG = "StickyListHeadersListView";
 	private static final String HEADER_HEIGHT = "headerHeight";
 	private static final String SUPER_INSTANCE_STATE = "superInstanceState";
-	
+
 	private OnScrollListener scrollListener;
 	private boolean areHeadersSticky;
 	private int headerBottomPosition;
@@ -54,40 +55,33 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 	private Long oldHeaderId = null;
 	private boolean headerHasChanged = true;
 	private boolean setupDone;
-	private Rect clippingRect = new Rect();
-	
+	private final Rect clippingRect = new Rect();
+
 	private DataSetObserver dataSetChangedObserver = new DataSetObserver() {
 		@Override
 		public void onChanged() {
 			reset();
 		}
+		@Override
 		public void onInvalidated() {
 			reset();
-		};
+		}
 	};
 
 	public StickyListHeadersListView(Context context) {
-		super(context);
-		setup();
+		this(context, null);
 	}
 
 	public StickyListHeadersListView(Context context, AttributeSet attrs) {
-		super(context, attrs);
-		TypedArray a = getContext().obtainStyledAttributes(attrs,R.styleable.StickyListHeadersListView);
-		setAreHeadersSticky(a.getBoolean(0, true));
-		a.recycle();
-		setup();
+		this(context, attrs, android.R.attr.listViewStyle);
 	}
 
 	public StickyListHeadersListView(Context context, AttributeSet attrs, int defStyle) {
 		super(context, attrs, defStyle);
-		TypedArray a = getContext().obtainStyledAttributes(attrs,R.styleable.StickyListHeadersListView);
-		setAreHeadersSticky(a.getBoolean(0, true));
+		TypedArray a = context.obtainStyledAttributes(attrs,R.styleable.StickyListHeadersListView);
+		setAreHeadersSticky(a.getBoolean(R.styleable.StickyListHeadersListView_areHeadersSticky, true));
 		a.recycle();
-		setup();
-	}
-	
-	private void setup() {
+
 		if(!setupDone){
 			setupDone = true;
 			super.setOnScrollListener(this);
@@ -99,23 +93,22 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 			setVerticalFadingEdgeEnabled(false);
 		}
 	}
-	
-	private void reset()
-	{
-	    headerBottomPosition = 0;
-	    headerHeight = -1;
-	    header = null;
-	    oldHeaderId = null;
-	    headerHasChanged = true;
+
+	private void reset() {
+		headerBottomPosition = 0;
+		headerHeight = -1;
+		header = null;
+		oldHeaderId = null;
+		headerHasChanged = true;
 	}
-	
+
 	@Override
 	public void onRestoreInstanceState(Parcelable state) {
 		headerHeight = ((Bundle)state).getInt(HEADER_HEIGHT);
 		headerHasChanged = true;
 		super.onRestoreInstanceState(((Bundle)state).getParcelable(SUPER_INSTANCE_STATE));
 	}
-	
+
 	@Override
 	public Parcelable onSaveInstanceState() {
 		Bundle instanceState = new Bundle();
@@ -123,14 +116,13 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 		instanceState.putParcelable(SUPER_INSTANCE_STATE, super.onSaveInstanceState());
 		return instanceState;
 	}
-	
+
 	@Override
-	public boolean performItemClick(View view, int position, long id)
-	{
-		view = view.findViewById(R.id.__stickylistheaders_list_item_view);
-	    return super.performItemClick(view, position, id);
+	public boolean performItemClick(View view, int position, long id) {
+		view = ((WrapperView) view).getItem();
+		return super.performItemClick(view, position, id);
 	}
-	
+
 	/**
 	 * can only be set to false if headers are sticky, not compatible with fading edges
 	 */
@@ -142,7 +134,7 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 			super.setVerticalFadingEdgeEnabled(verticalFadingEdgeEnabled);
 		}
 	}
-	
+
 	@Override
 	public void setDivider(Drawable divider) {
 		if(setupDone){
@@ -154,7 +146,7 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 			super.setDivider(divider);
 		}
 	}
-	
+
 	@Override
 	public void setDividerHeight(int height) {
 		if(setupDone){
@@ -166,12 +158,12 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 			super.setDividerHeight(height);
 		}
 	}
-	
+
 	@Override
 	public void setOnScrollListener(OnScrollListener l) {
 		scrollListener = l;
 	}
-	
+
 	public void setAreHeadersSticky(boolean areHeadersSticky) {
 		if(areHeadersSticky){
 			super.setVerticalFadingEdgeEnabled(false);
@@ -182,18 +174,19 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 	public boolean areHeadersSticky() {
 		return areHeadersSticky;
 	}
-	
+
 	@Override
 	public void setAdapter(ListAdapter adapter) {
 		if(!clipToPaddingHasBeenSet){
 			clippingToPadding = true;
 		}
 		if(!(adapter instanceof StickyListHeadersAdapter)) throw new IllegalArgumentException("Adapter must be a subclass of StickyListHeadersAdapter");
-		((StickyListHeadersAdapter)adapter).setDivider(divider);
-		((StickyListHeadersAdapter)adapter).setDividerHeight(dividerHeight);
+		StickyListHeadersAdapter stickyAdapter = (StickyListHeadersAdapter) adapter;
+		stickyAdapter.setDivider(divider);
+		stickyAdapter.setDividerHeight(dividerHeight);
 		reset();
-		super.setAdapter(adapter);
-		getAdapter().registerDataSetObserver(dataSetChangedObserver);
+		super.setAdapter(stickyAdapter);
+		stickyAdapter.registerDataSetObserver(dataSetChangedObserver);
 	}
 
 	@Override
@@ -219,7 +212,7 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 			}else{
 				clippingRect.top = 0;
 			}
-			
+
 			canvas.save();
 			canvas.clipRect(clippingRect);
 			canvas.translate(getPaddingLeft(), top);
@@ -227,7 +220,7 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 			canvas.restore();
 		}
 	}
-	
+
 	@Override
 	public void setClipToPadding(boolean clipToPadding) {
 		super.setClipToPadding(clipToPadding);
@@ -244,40 +237,42 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 			scrollChanged(firstVisibleItem);
 		}
 	}
-	
+
 	private void scrollChanged(int firstVisibleItem){
 		if(getAdapter()==null || getAdapter().getCount() == 0) return;
-		
+
 		firstVisibleItem = getFixedFirstVisibleItem(firstVisibleItem);
 		if(areHeadersSticky){
-			if(getChildCount()!=0){
-				
-				View viewToWatch = super.getChildAt(0);
-				for(int i = 1;i<getChildCount();i++){
-					
+			final int childCount = getChildCount();
+			if(childCount!=0){
+
+				WrapperView viewToWatch = (WrapperView) super.getChildAt(0);
+				for(int i = 1;i<childCount;i++){
+					WrapperView child = (WrapperView) super.getChildAt(i);
+
 					int firstChildDistance;
 					if(clippingToPadding){
 						firstChildDistance = Math.abs((viewToWatch.getTop() - getPaddingTop()));
 					}else{
 						firstChildDistance = Math.abs(viewToWatch.getTop());
 					}
-					
+
 					int secondChildDistance;
 					if(clippingToPadding){
-						secondChildDistance = Math.abs((super.getChildAt(i).getTop() - getPaddingTop()) - headerHeight);
+						secondChildDistance = Math.abs((child.getTop() - getPaddingTop()) - headerHeight);
 					}else{
-						secondChildDistance = Math.abs(super.getChildAt(i).getTop() - headerHeight);
+						secondChildDistance = Math.abs(child.getTop() - headerHeight);
 					}
-					
-					if(!(Boolean)viewToWatch.getTag() || ((Boolean)super.getChildAt(i).getTag() && secondChildDistance<firstChildDistance)){
-						viewToWatch = super.getChildAt(i);
+
+					if(!viewToWatch.hasHeader() || (child.hasHeader() && secondChildDistance<firstChildDistance)){
+						viewToWatch = child;
 					}
 				}
-				
-				if((Boolean)viewToWatch.getTag()){
-					
-					if(headerHeight<0) headerHeight=viewToWatch.findViewById(R.id.__stickylistheaders_header_view).getHeight();
-					
+
+				if(viewToWatch.hasHeader()){
+
+					if(headerHeight<0) headerHeight=viewToWatch.getHeader().getHeight();
+
 					if(firstVisibleItem == 0 && super.getChildAt(0).getTop()>0 && !clippingToPadding){
 						headerBottomPosition = 0;
 					}else{
@@ -296,29 +291,32 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 					}
 				}
 			}
-			
+
 			long currentHeaderId = ((StickyListHeadersAdapter)getAdapter()).getHeaderId(firstVisibleItem);
-			
+
 			if(oldHeaderId == null || oldHeaderId != currentHeaderId){
 				headerHasChanged = true;
 				header = ((StickyListHeadersAdapter)getAdapter()).getHeaderView(firstVisibleItem, header);
 				header.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, headerHeight));
 			}
 			oldHeaderId = currentHeaderId;
-			for(int i = 0;i<getChildCount();i++){
-				if((Boolean)super.getChildAt(i).getTag()){
-					if(super.getChildAt(i).getTop()<(clippingToPadding ? getPaddingTop() : 0)){
-						super.getChildAt(i).findViewById(R.id.__stickylistheaders_header_view).setVisibility(View.INVISIBLE);
+			int top = clippingToPadding ? getPaddingTop() : 0;
+			for(int i = 0;i<childCount;i++){
+				WrapperView child = (WrapperView) super.getChildAt(i);
+				if(child.hasHeader()){
+					View childHeader = child.getHeader();
+					if(child.getTop()<top){
+						childHeader.setVisibility(View.INVISIBLE);
 					}else{
-						super.getChildAt(i).findViewById(R.id.__stickylistheaders_header_view).setVisibility(View.VISIBLE);
+						childHeader.setVisibility(View.VISIBLE);
 					}
 				}
 			}
 		}
 	}
-	
+
 	private int getFixedFirstVisibleItem(int firstVisibleItem){
-		if(Build.VERSION.SDK_INT < 11){
+		if(Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB){
 
 			for(int i = 0 ; i<getChildCount() ; i++){
 				if(getChildAt(i).getBottom()>=0){
@@ -326,7 +324,7 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 					break;
 				}
 			}
-			
+
 			//work around to fix bug with firstVisibleItem being to high because listview does not take clipToPadding=false into account
 			if(!clippingToPadding && getPaddingTop()>0){
 				if(super.getChildAt(0).getTop() > 0){
@@ -336,8 +334,8 @@ public class StickyListHeadersListView extends ListView implements OnScrollListe
 				}
 			}
 		}
-		
-		Log.d("", ""+getChildAt(0).getBottom());
+
+		if (BuildConfig.DEBUG) Log.d(TAG, String.valueOf(getChildAt(0).getBottom()));
 		return firstVisibleItem;
 	}
 

--- a/library/src/com/emilsjolander/components/StickyListHeaders/WrapperView.java
+++ b/library/src/com/emilsjolander/components/StickyListHeaders/WrapperView.java
@@ -1,4 +1,4 @@
-package com.emilsjolander.components.StickyListHeaders;
+package com.emilsjolander.components.stickylistheaders;
 
 import android.content.Context;
 import android.view.View;
@@ -23,26 +23,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
  *
  */
-public class WrapperView {
-	
-	private LinearLayout v;
-	
+public class WrapperView extends LinearLayout {
+
+	private View item;
+	private View divider;
+	private View header;
+
 	public WrapperView(Context c) {
-		v = new LinearLayout(c);
-		v.setId(R.id.__stickylistheaders_wrapper_view);
-		v.setOrientation(LinearLayout.VERTICAL);
-	}
-	
-	public WrapperView(View v) {
-		this.v = (LinearLayout) v;
+		super(c, null);
+		setOrientation(VERTICAL);
 	}
 
-	public View wrapViews(View... views){
-		v.removeAllViews();
-		for(View child : views){
-			v.addView(child);
-		}
-		return v;
+	public View getItem() {
+		return item;
+	}
+
+	public View getDivider() {
+		return divider;
+	}
+
+	public View getHeader() {
+		return header;
+	}
+
+	public boolean hasHeader() {
+		return header != null;
+	}
+
+	public WrapperView wrapViews(View item, View divider, View header){
+		removeAllViews();
+		this.item = item;
+		this.divider = divider;
+		this.header = header;
+		if (divider != null) addView(divider);
+		if (header != null) addView(header);
+		addView(item);
+		return this;
 	}
 
 }

--- a/sample/AndroidManifest.xml
+++ b/sample/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.emilsjolander.components.StickyListHeaders.test"
+    package="com.emilsjolander.components.stickylistheaders.test"
     android:versionCode="1"
     android:versionName="1.0" >
 
@@ -14,7 +14,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name" >
         <activity
-            android:name="TestActivity"
+            android:name=".TestActivity"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/sample/res/layout/main.xml
+++ b/sample/res/layout/main.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:slh="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical" xmlns:app="http://schemas.android.com/apk/res/com.emilsjolander.components.StickyListHeaders.test">
+    android:orientation="vertical">
 
-    <com.emilsjolander.components.StickyListHeaders.StickyListHeadersListView
-        xmlns:slh="http://schemas.android.com/apk/res-auto"
+    <com.emilsjolander.components.stickylistheaders.StickyListHeadersListView
         android:id="@+id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         slh:areHeadersSticky="true"
         android:padding="16dip"
         android:clipToPadding="false"/>
-        
+
 </LinearLayout>

--- a/sample/src/com/emilsjolander/components/stickylistheaders/test/TestActivity.java
+++ b/sample/src/com/emilsjolander/components/stickylistheaders/test/TestActivity.java
@@ -1,17 +1,16 @@
-package com.emilsjolander.components.StickyListHeaders.test;
+package com.emilsjolander.components.stickylistheaders.test;
 
 import android.app.Activity;
 import android.os.Bundle;
 import android.widget.AbsListView;
 import android.widget.AbsListView.OnScrollListener;
+import com.emilsjolander.components.stickylistheaders.StickyListHeadersListView;
 
-import com.emilsjolander.components.StickyListHeaders.R;
-import com.emilsjolander.components.StickyListHeaders.StickyListHeadersListView;
 /**
- * 
+ *
  * @author Emil Sj�lander
- * 
- * 
+ *
+ *
 Copyright 2012 Emil Sj�lander
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,22 +29,21 @@ limitations under the License.
 public class TestActivity extends Activity implements OnScrollListener {
 
 	private static final String KEY_LIST_POSITION = "KEY_LIST_POSITION";
-	private StickyListHeadersListView stickyList;
 	private int firstVisible;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.main);
-		stickyList = (StickyListHeadersListView) findViewById(R.id.list);
+		StickyListHeadersListView stickyList = (StickyListHeadersListView) findViewById(R.id.list);
 		stickyList.setOnScrollListener(this);
-		
+
 		if (savedInstanceState != null) {
 			firstVisible = savedInstanceState.getInt(KEY_LIST_POSITION);
 		}
 
 		stickyList.setAdapter(new TestBaseAdapter(this));
-		stickyList.setSelection(firstVisible );
+		stickyList.setSelection(firstVisible);
 
 		//        Cursor cursor = getContentResolver().query(ContactsContract.Contacts.CONTENT_URI, null, null, null, null);
 		//        stickyList.setAdapter(new TestCursorAdapter(this,cursor));
@@ -56,7 +54,7 @@ public class TestActivity extends Activity implements OnScrollListener {
 		super.onSaveInstanceState(outState);
 		outState.putInt(KEY_LIST_POSITION, firstVisible);
 	}
-	
+
 	@Override
 	public void onScroll(AbsListView view, int firstVisibleItem,
 			int visibleItemCount, int totalItemCount) {
@@ -65,8 +63,6 @@ public class TestActivity extends Activity implements OnScrollListener {
 
 	@Override
 	public void onScrollStateChanged(AbsListView view, int scrollState) {
-		// TODO Auto-generated method stub
-
 	}
 
 }

--- a/sample/src/com/emilsjolander/components/stickylistheaders/test/TestBaseAdapter.java
+++ b/sample/src/com/emilsjolander/components/stickylistheaders/test/TestBaseAdapter.java
@@ -1,17 +1,17 @@
-package com.emilsjolander.components.StickyListHeaders.test;
+package com.emilsjolander.components.stickylistheaders.test;
 
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 
-import com.emilsjolander.components.StickyListHeaders.R;
-import com.emilsjolander.components.StickyListHeaders.StickyListHeadersBaseAdapter;
+import com.emilsjolander.components.stickylistheaders.R;
+import com.emilsjolander.components.stickylistheaders.StickyListHeadersBaseAdapter;
 /**
- * 
+ *
  * @author Emil Sj�lander
- * 
- * 
+ *
+ *
 Copyright 2012 Emil Sj�lander
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ limitations under the License.
  *
  */
 public class TestBaseAdapter extends StickyListHeadersBaseAdapter {
-	
+
 	private String[] countries;
 	private LayoutInflater inflater;
 
@@ -64,7 +64,7 @@ public class TestBaseAdapter extends StickyListHeadersBaseAdapter {
 	@Override
 	public View getHeaderView(int position, View convertView) {
 		HeaderViewHolder holder;
-		
+
 		if(convertView == null){
 			holder = new HeaderViewHolder();
 			convertView = inflater.inflate(R.layout.header, null);
@@ -73,13 +73,13 @@ public class TestBaseAdapter extends StickyListHeadersBaseAdapter {
 		}else{
 			holder = (HeaderViewHolder) convertView.getTag();
 		}
-		
+
 		//set header text as first char in name
 		holder.text.setText(countries[position].subSequence(0, 1));
-		
+
 		return convertView;
 	}
-	
+
 	class HeaderViewHolder{
 		TextView text;
 	}
@@ -89,7 +89,7 @@ public class TestBaseAdapter extends StickyListHeadersBaseAdapter {
 	@Override
 	protected View getView(int position, View convertView) {
 		ViewHolder holder;
-		
+
 		if(convertView == null){
 			holder = new ViewHolder();
 			convertView = inflater.inflate(R.layout.test_list_item_layout, null);
@@ -98,12 +98,12 @@ public class TestBaseAdapter extends StickyListHeadersBaseAdapter {
 		}else{
 			holder = (ViewHolder) convertView.getTag();
 		}
-		
+
 		holder.text.setText(countries[position]);
-		
+
 		return convertView;
 	}
-	
+
 	class ViewHolder{
 		TextView text;
 	}

--- a/sample/src/com/emilsjolander/components/stickylistheaders/test/TestCursorAdapter.java
+++ b/sample/src/com/emilsjolander/components/stickylistheaders/test/TestCursorAdapter.java
@@ -1,4 +1,4 @@
-package com.emilsjolander.components.StickyListHeaders.test;
+package com.emilsjolander.components.stickylistheaders.test;
 
 import android.content.Context;
 import android.database.Cursor;
@@ -8,11 +8,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import com.emilsjolander.components.StickyListHeaders.R;
-import com.emilsjolander.components.StickyListHeaders.StickyListHeadersCursorAdapter;
+import com.emilsjolander.components.stickylistheaders.R;
+import com.emilsjolander.components.stickylistheaders.StickyListHeadersCursorAdapter;
 
 public class TestCursorAdapter extends StickyListHeadersCursorAdapter {
-	
+
 	private LayoutInflater inflater;
 
 	public TestCursorAdapter(Context context, Cursor c) {
@@ -28,7 +28,7 @@ public class TestCursorAdapter extends StickyListHeadersCursorAdapter {
 		v.setTag(holder);
 		return v;
 	}
-	
+
 	class HeaderViewHolder{
 		TextView text;
 	}
@@ -59,7 +59,7 @@ public class TestCursorAdapter extends StickyListHeadersCursorAdapter {
 		v.setTag(holder);
 		return v;
 	}
-	
+
 	class ViewHolder{
 		TextView text;
 	}


### PR DESCRIPTION
- Use all lowercase package name as per Java specifications.
- Avoid redundant calls to methods (especially with casts).
- Avoid using IDs to look up views. Make `WrapperView` a bit smarter instead.
- Avoid using view tag to keep track of whether or not an item has a header. Make `WrapperView` a bit smarter instead.
- Cache loop conditional when it called somewhere else (e.g., `getChildCount()`).
- Force `StickyListHeadersAdapter` to be an extension of `ListAdapter`.
- Mark three-arg `getView` method as `final` so there is no way it can be accidentally overriden.
