### PR TITLE
fixed broken setActivate / state_activated on API 11+

### DIFF
--- a/library/src/com/emilsjolander/components/stickylistheaders/CheckableWrapperView.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/CheckableWrapperView.java
@@ -1,0 +1,48 @@
+package com.emilsjolander.components.stickylistheaders;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.view.View;
+import android.widget.Checkable;
+
+/**
+ *
+ * @author Emil Sjölander
+ *
+ *
+ *         Copyright 2012 Emil Sjölander
+ *
+ *         Licensed under the Apache License, Version 2.0 (the "License"); you
+ *         may not use this file except in compliance with the License. You may
+ *         obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *         implied. See the License for the specific language governing
+ *         permissions and limitations under the License.
+ *
+ */
+class CheckableWrapperView extends WrapperView implements Checkable {
+
+	public CheckableWrapperView(final Context context) {
+		super(context);
+	}
+
+	@Override
+	public boolean isChecked() {
+		return ((Checkable) item).isChecked();
+	}
+
+	@Override
+	public void setChecked(final boolean checked) {
+		((Checkable) item).setChecked(checked);
+	}
+
+	@Override
+	public void toggle() {
+		setChecked(!isChecked());
+	}
+}

--- a/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersAdapterWrapper.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersAdapterWrapper.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
+import android.widget.Checkable;
 import android.widget.ListAdapter;
 
 /**
@@ -19,16 +20,16 @@ import android.widget.ListAdapter;
  * and
  * {@link StickyListHeadersAdapter#getHeaderView(int, android.view.View, android.view.ViewGroup)}
  * appropriately.
- * 
+ *
  * @author Jake Wharton (jakewharton@gmail.com)
  */
 final class StickyListHeadersAdapterWrapper extends BaseAdapter {
 
-	
+
 	public interface OnHeaderClickListener{
 		public void onHeaderClick(View header, int itemPosition, long headerId);
 	}
-	
+
 	private final List<View> headerCache = new ArrayList<View>();
 	private final Context context;
 	final StickyListHeadersAdapter delegate;
@@ -136,7 +137,7 @@ final class StickyListHeadersAdapterWrapper extends BaseAdapter {
 		//if the header isn't clickable, the listselector will be drawn on top of the header
 		header.setClickable(true);
 		header.setOnClickListener(new OnClickListener() {
-			
+
 			@Override
 			public void onClick(View v) {
 				if(onHeaderClickListener != null){
@@ -157,8 +158,7 @@ final class StickyListHeadersAdapterWrapper extends BaseAdapter {
 
 	@Override
 	public WrapperView getView(int position, View convertView, ViewGroup parent) {
-		WrapperView wv = (convertView == null) ? new WrapperView(context)
-				: (WrapperView) convertView;
+		WrapperView wv = (convertView == null) ? new WrapperView(context) : (WrapperView) convertView;
 		View item = delegate.getView(position, wv.item, wv);
 		View header = null;
 		if (previousPositionHasSameHeader(position)) {
@@ -166,12 +166,18 @@ final class StickyListHeadersAdapterWrapper extends BaseAdapter {
 		} else {
 			header = configureHeader(wv, position);
 		}
+		if((item instanceof Checkable) && !(wv instanceof CheckableWrapperView)) {
+			// Need to create Checkable subclass of WrapperView for ListView to work correctly
+			wv = new CheckableWrapperView(context);
+		} else if(!(item instanceof Checkable) && (wv instanceof CheckableWrapperView)) {
+			wv = new WrapperView(context);
+		}
 		wv.update(item, header, divider, dividerHeight);
 		return wv;
 	}
-	
+
 	public void setOnHeaderClickListener(OnHeaderClickListener onHeaderClickListener){
 		this.onHeaderClickListener = onHeaderClickListener;
 	}
-	
+
 }

--- a/library/src/com/emilsjolander/components/stickylistheaders/WrapperView.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/WrapperView.java
@@ -6,14 +6,14 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Checkable;
+import android.view.ViewParent;
 
 /**
  * 
- * @author Emil Sj�lander
+ * @author Emil Sjölander
  * 
  * 
- *         Copyright 2012 Emil Sj�lander
+ *         Copyright 2012 Emil Sjölander
  * 
  *         Licensed under the Apache License, Version 2.0 (the "License"); you
  *         may not use this file except in compliance with the License. You may
@@ -28,13 +28,12 @@ import android.widget.Checkable;
  *         permissions and limitations under the License.
  * 
  */
-final class WrapperView extends ViewGroup implements Checkable {
+class WrapperView extends ViewGroup {
 
 	View item;
 	Drawable divider;
 	int dividerHeight;
 	View header;
-	boolean checkable;
 
 	public WrapperView(Context c) {
 		super(c);
@@ -48,9 +47,12 @@ final class WrapperView extends ViewGroup implements Checkable {
 		if (this.item != item) {
 			removeView(this.item);
 			this.item = item;
-			// keep track of whether or not the wrapped item is Checkable
-			// to know if we can delegate Checkable methods to it.
-			checkable = item instanceof Checkable;
+			final ViewParent parent = item.getParent();
+			if(parent != null && parent != this) {
+				if(parent instanceof ViewGroup) {
+					((ViewGroup) parent).removeView(item);
+				}
+			}
 			addView(item);
 		}
 
@@ -139,25 +141,5 @@ final class WrapperView extends ViewGroup implements Checkable {
 			}
 			divider.draw(canvas);
 		}
-	}
-
-	@Override
-	public boolean isChecked() {
-		return checkable ? ((Checkable) item).isChecked() : false;
-	}
-
-	@Override
-	public void setChecked(boolean checked) {
-		if (checkable) {
-			// delegate checked state to wrapped view if it implements Checkable
-			// interface to support listviews that indicate choices (single,
-			// multiple, multiple modal).
-			((Checkable) item).setChecked(checked);
-		}
-	}
-
-	@Override
-	public void toggle() {
-		setChecked(!isChecked());
 	}
 }


### PR DESCRIPTION
As I mentioned in issue #52 the newly implemented choice mode support breaks the use of setActivate / state_activated on API 11+. 
To fix this I have moved the Checkable-implementation into a subclass of WrapperView and added a check in `getView` of `StickyListHeadersAdapterWrapper`.

I also fixed a strange bug I encountered when using this library with EndlessAdapter (cwac-endless). (see lines 50-55 in `WrapperView`)
