### PR TITLE
fix crash when invoke notifyDataSetChanged() while scrolling

### DIFF
--- a/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersAdapterWrapper.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersAdapterWrapper.java
@@ -23,7 +23,7 @@ import android.widget.ListAdapter;
  *
  * @author Jake Wharton (jakewharton@gmail.com)
  */
-final class StickyListHeadersAdapterWrapper extends BaseAdapter {
+final class StickyListHeadersAdapterWrapper extends BaseAdapter implements StickyListHeadersAdapter {
 
 
 	public interface OnHeaderClickListener{
@@ -32,7 +32,7 @@ final class StickyListHeadersAdapterWrapper extends BaseAdapter {
 
 	private final List<View> headerCache = new ArrayList<View>();
 	private final Context context;
-	final StickyListHeadersAdapter delegate;
+	private final StickyListHeadersAdapter delegate;
 	private Drawable divider;
 	private int dividerHeight;
 	private DataSetObserver dataSetObserver = new DataSetObserver() {
@@ -178,6 +178,46 @@ final class StickyListHeadersAdapterWrapper extends BaseAdapter {
 
 	public void setOnHeaderClickListener(OnHeaderClickListener onHeaderClickListener){
 		this.onHeaderClickListener = onHeaderClickListener;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return delegate.equals(o); 
+	}
+
+	@Override
+	public View getDropDownView(int position, View convertView, ViewGroup parent) {
+		return ((BaseAdapter) delegate).getDropDownView(position, convertView, parent);
+	}
+
+	@Override
+	public int hashCode() {
+		return delegate.hashCode();
+	}
+
+	@Override
+	public void notifyDataSetChanged() {
+		((BaseAdapter) delegate).notifyDataSetChanged();
+	}
+
+	@Override
+	public void notifyDataSetInvalidated() {
+		((BaseAdapter) delegate).notifyDataSetInvalidated();
+	}
+
+	@Override
+	public String toString() {
+		return delegate.toString();
+	}
+
+	@Override
+	public View getHeaderView(int position, View convertView, ViewGroup parent) {
+		return delegate.getHeaderView(position, convertView, parent);
+	}
+
+	@Override
+	public long getHeaderId(int position) {
+		return delegate.getHeaderId(position);
 	}
 
 }

--- a/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
@@ -207,11 +207,6 @@ public class StickyListHeadersListView extends ListView implements
 	}
 
 	@Override
-	public StickyListHeadersAdapter getAdapter() {
-		return adapter == null ? null : adapter.delegate;
-	}
-
-	@Override
 	protected void dispatchDraw(Canvas canvas) {
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.FROYO) {
 			scrollChanged(getFirstVisiblePosition());
@@ -303,10 +298,10 @@ public class StickyListHeadersListView extends ListView implements
 			return;
 		}
 
-		long newHeaderId = adapter.delegate.getHeaderId(firstVisibleItem);
+		long newHeaderId = adapter.getHeaderId(firstVisibleItem);
 		if (currentHeaderId == null || currentHeaderId != newHeaderId) {
 			headerPosition = firstVisibleItem;
-			header = adapter.delegate.getHeaderView(headerPosition, header,
+			header = adapter.getHeaderView(headerPosition, header,
 					this);
 			measureHeader();
 		}


### PR DESCRIPTION
If i invoke "notifyDataSetChanged()" while scrolling the listview, it will crash.

I found that "StickyListHeadersAdapterWrapper" is a wrapper or a proxy for the adapter passed to ListView. StickyListHeadersAdapterWrapper extends BaseAdapter but has not override all the method in BaseAdapter. This may be the cause of the crash.
