### PR TITLE
Fix count caches not being invalidated

### DIFF
--- a/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
@@ -409,7 +409,7 @@ public class StickyListHeadersListView extends ListView implements
 		}
 
 		if (this.adapter != null) {
-			this.adapter.unregisterDataSetObserver(dataSetChangedObserver);
+			this.adapter.unregisterInternalDataSetObserver(dataSetChangedObserver);
 			this.adapter = null;
 		}
 
@@ -423,7 +423,7 @@ public class StickyListHeadersListView extends ListView implements
 			}
 			this.adapter.setDivider(divider);
 			this.adapter.setDividerHeight(dividerHeight);
-			this.adapter.registerDataSetObserver(dataSetChangedObserver);
+			this.adapter.registerInternalDataSetObserver(dataSetChangedObserver);
 		}
 
 		currentHeaderId = null;


### PR DESCRIPTION
Should probably fix #92

The problem occurs because of a change after Gingerbread where observers are called in the reverse order they were registered. This fixes it by defining our own observer list and making sure we clear any caches before the other observers are called.
