### PR TITLE
Inherit default header height when sticking it

### DIFF
--- a/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListViewWrapper.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListViewWrapper.java
@@ -118,7 +118,7 @@ public class StickyListHeadersListViewWrapper extends FrameLayout {
 			View list = getChildAt(0);
 			LayoutParams params = new LayoutParams(list.getMeasuredWidth()
 					- list.getPaddingLeft() - list.getPaddingRight(),
-					header.getLayoutParams().height);
+					header.getLayoutParams() != null ? header.getLayoutParams().height : LayoutParams.WRAP_CONTENT);
 			params.leftMargin = list.getPaddingLeft();
 			params.rightMargin = list.getPaddingRight();
 			params.gravity = Gravity.TOP;


### PR DESCRIPTION
I have the situation in which my headerView has a fixed height and when it gets sticked, that height is missing, so I updated the method in wich this change is done so the header always have the stablished height.

Also you may consider inheriting the top and bottom paddings as well (I haven't tested it).
