### PR TITLE
Added a method to StickyHeadersListView to get the item View of a list i...

### DIFF
--- a/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
@@ -276,21 +276,6 @@ public class StickyListHeadersListView extends ListView {
 		drawStickyHeader(canvas);
 	}
 	
-	
-	/*
-	 * Returns the item for for the wrapperView.
-	 * Useful for things like when you need to animate a list item, but don't want
-	 * to animate the Header view as well
-	 */
-	public View getItemView(View wrapperView) {
-		if (!(wrapperView instanceof WrapperView))
-			throw new ClassCastException("View is not an instance of WrapperView");
-
-		return ((WrapperView) wrapperView).mItem;
-
-	}
-	
-
 	private void positionSelectorRect() {
 		if (!mSelectorRect.isEmpty()) {
 			int selectorPosition = getSelectorPosition();


### PR DESCRIPTION
Added a method to StickyHeadersListView to get the item View of a list item. This returns just the item View, without a header attached. Useful for something like animating a list item, where you just need the item view, with no header.
