### PR TITLE
setSelection not respect StickyHeader

### DIFF
--- a/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
@@ -1,8 +1,6 @@
 package com.emilsjolander.components.stickylistheaders;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.database.DataSetObserver;
 import android.graphics.Canvas;
@@ -10,7 +8,6 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -19,6 +16,9 @@ import android.widget.AbsListView;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.SectionIndexer;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 
 /**
  * @author Emil Sjölander
@@ -159,6 +159,40 @@ public class StickyListHeadersListView extends ListView {
 			view = ((WrapperView) view).mItem;
 		}
 		return super.performItemClick(view, position, id);
+	}
+
+	@Override
+	public void setSelectionFromTop(int position, int y) {
+		if (hasStickyHeaderAtPosition(position)) {
+			y += getHeaderHeight();
+		}
+		super.setSelectionFromTop(position, y);
+	}
+
+	@SuppressLint("NewApi")
+	@Override
+	public void smoothScrollToPositionFromTop(int position, int offset) {
+		if (hasStickyHeaderAtPosition(position)) {
+			offset += getHeaderHeight();
+		}
+		super.smoothScrollToPositionFromTop(position, offset);
+	}
+
+	@SuppressLint("NewApi")
+	@Override
+	public void smoothScrollToPositionFromTop(int position, int offset,
+			int duration) {
+		if (hasStickyHeaderAtPosition(position)) {
+			offset += getHeaderHeight();
+		}
+		super.smoothScrollToPositionFromTop(position, offset, duration);
+	}
+
+	private boolean hasStickyHeaderAtPosition(int position) {
+		return mAreHeadersSticky
+				&& position > 0
+				&& mAdapter.getHeaderId(position) == mAdapter
+						.getHeaderId(position - 1);
 	}
 
 	@Override


### PR DESCRIPTION
Hey Emil,

i had some problems with setSelection().
## Expected behaviour

`setSelection(position)` should jump to the listitem. With the listitem below the sticky header.
## Actual behaviour

`setSeletion(position)` to an listitem with a sticky header, the list item is covered by the sticky header
## Problem

`setSeletion(position)` doesn't respect the height of hte sticky header if ther is one at the selected position.
## Solution
1. test if there is an sticky listitem at the position
2. add header height to y-offset
