### PR TITLE
Add version checking when getting AbslistView element "mSelectorPosition...

### DIFF
--- a/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
@@ -125,9 +125,10 @@ public class StickyListHeadersListView extends ListView {
 			selectorRectField.setAccessible(true);
 			mSelectorRect = (Rect) selectorRectField.get(this);
 
-			mSelectorPositionField = AbsListView.class
-					.getDeclaredField("mSelectorPosition");
-			mSelectorPositionField.setAccessible(true);
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+				mSelectorPositionField = AbsListView.class.getDeclaredField("mSelectorPosition");
+				mSelectorPositionField.setAccessible(true);
+			}
 		} catch (NoSuchFieldException e) {
 			e.printStackTrace();
 		} catch (IllegalArgumentException e) {


### PR DESCRIPTION
Add version checking when getting AbslistView element "mSelectorPosition" in StickyListHeadersListView.java to avoid NoSuchFieldException when running on android version < 4.0

This field does not exist in android version < 4.0. This is done only to avoid LogCat spam everytime you enter on the listview layout
