### PR TITLE
allow to suppress grouping by returning null from getHeaderView

### DIFF
--- a/library/src/com/emilsjolander/components/stickylistheaders/AdapterWrapper.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/AdapterWrapper.java
@@ -127,21 +127,20 @@ class AdapterWrapper extends BaseAdapter implements StickyListHeadersAdapter {
 	private View configureHeader(WrapperView wv, final int position) {
 		View header = wv.mHeader == null ? popHeader() : wv.mHeader;
 		header = mDelegate.getHeaderView(position, header, wv);
-		if (header == null) {
-			throw new NullPointerException("Header view must not be null.");
-		}
-		//if the header isn't clickable, the listselector will be drawn on top of the header
-		header.setClickable(true);
-		header.setOnClickListener(new OnClickListener() {
+		if (header != null) {
+			//if the header isn't clickable, the listselector will be drawn on top of the header
+			header.setClickable(true);
+			header.setOnClickListener(new OnClickListener() {
 
-			@Override
-			public void onClick(View v) {
-				if(mOnHeaderClickListener != null){
-					long headerId = mDelegate.getHeaderId(position);
-					mOnHeaderClickListener.onHeaderClick(v, position, headerId);
+				@Override
+				public void onClick(View v) {
+					if(mOnHeaderClickListener != null){
+						long headerId = mDelegate.getHeaderId(position);
+						mOnHeaderClickListener.onHeaderClick(v, position, headerId);
+					}
 				}
-			}
-		});
+			});
+		}
 		return header;
 	}
 

--- a/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/com/emilsjolander/components/stickylistheaders/StickyListHeadersListView.java
@@ -364,6 +364,7 @@ public class StickyListHeadersListView extends ListView {
 		canvas.restore();
 	}
 
+	@SuppressLint("NewApi")
 	private void measureHeader() {
 
 		int widthMeasureSpec = MeasureSpec.makeMeasureSpec(getWidth()
@@ -433,7 +434,8 @@ public class StickyListHeadersListView extends ListView {
 			mHeaderPosition = firstVisibleItem;
 			mCurrentHeaderId = mAdapter.getHeaderId(firstVisibleItem);
 			mHeader = mAdapter.getHeaderView(mHeaderPosition, mHeader, this);
-			measureHeader();
+			if (mHeader !=	null)
+				measureHeader();
 		}
 
 		int childCount = getChildCount();


### PR DESCRIPTION
this change allows to use StickyListHeaders without grouping. This allows to have the user switch grouping on and off without having to replace the StickyListView with a normal ListView.
This is used in https://play.google.com/store/apps/details?id=org.totschnig.myexpenses
