### PR TITLE
Update StickyListHeadersListView.java

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -155,7 +155,7 @@ public class StickyListHeadersListView extends FrameLayout {
 				if (divider != null) {
 					mDivider = divider;
 				}
-				mDividerHeight = a.getInt(R.styleable.StickyListHeadersListView_android_dividerHeight, mDividerHeight);
+				mDividerHeight = a.getDimensionPixelSize(R.styleable.StickyListHeadersListView_android_dividerHeight, 0);
 
 				// StickyListHeaders attributes
 				mAreHeadersSticky = a.getBoolean(R.styleable.StickyListHeadersListView_hasStickyHeaders, true);


### PR DESCRIPTION
fix when use `android:dividerHeight="0dp"`

``` java
 Caused by: java.lang.NumberFormatException: Invalid int: ".0dip"
```
