### PR TITLE
Fixes "top" positioning

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -507,8 +507,8 @@ public class StickyListHeadersListView extends FrameLayout {
 
 	private int getHeaderOverlap(int position) {
 		boolean isStartOfSection = isStartOfSection(position);
-		if (!isStartOfSection) {
-			final View header = mAdapter.getView(position, null, mList);
+		if (isStartOfSection) {
+			View header = mAdapter.getHeaderView(position, null, mList);
 			if (header == null) {
 				throw new NullPointerException("header may not be null");
 			}


### PR DESCRIPTION
1) The logic needs to pull the Header View, not the list item View.

2) the "if" condition appears to be reversed.  I don't know why exactly, but the new way works perfectly, but the old way is broken.
