### PR TITLE
Removed VERSION_CODE from gradle.properties.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 VERSION_NAME=2.1.1
-VERSION_CODE=77
 GROUP=se.emilsjolander
 
 POM_DESCRIPTION=A small android library that makes it easy to make lists with section headers that stick to the top until a new section header comes along.


### PR DESCRIPTION
You don't need this property. It was originally used for the sample APK (have a look at Chris Banes' ActionBar-PullToRefresh repository).
