### PR TITLE
Updated to Gradle 1.9 and gradle tools 0.7 for android studio 0.4.1+ compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.6.+'
+        classpath 'com.android.tools.build:gradle:0.7.+'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.8-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-all.zip


### PR DESCRIPTION
Need to update the Gradle tools to 1.9 and the tools to 0.7 to ensure
compatibility with Android studio 0.4.1 and above. More at
http://tools.android.com/recent/androidstudio041released

Imports/builds with the newer version of android studio will not work without this.
