### PR TITLE
Change access modifier for onRestoreInstanceState

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -995,7 +995,7 @@ public class StickyListHeadersListView extends FrameLayout {
     }
 
     @Override
-    protected void onRestoreInstanceState(Parcelable state) {
+    public void onRestoreInstanceState(Parcelable state) {
         super.onRestoreInstanceState(BaseSavedState.EMPTY_STATE);
         mList.onRestoreInstanceState(state);
     }


### PR DESCRIPTION
Matches the modifier provided by AbsListView: http://developer.android.com/reference/android/widget/AbsListView.html#onRestoreInstanceState(android.os.Parcelable)
