### PR TITLE
Make setOnTouchListener() work properly

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.util.SparseBooleanArray;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AbsListView;
@@ -673,6 +674,20 @@ public class StickyListHeadersListView extends FrameLayout {
 
     public void setOnScrollListener(OnScrollListener onScrollListener) {
         mOnScrollListenerDelegate = onScrollListener;
+    }
+
+    @Override
+    public void setOnTouchListener(final OnTouchListener l) {
+        if (l != null) {
+            mList.setOnTouchListener(new OnTouchListener() {
+                @Override
+                public boolean onTouch(View v, MotionEvent event) {
+                    return l.onTouch(StickyListHeadersListView.this, event);
+                }
+            });
+        } else {
+            mList.setOnTouchListener(null);
+        }
     }
 
     public void setOnItemClickListener(OnItemClickListener listener) {

--- a/sample/src/se/emilsjolander/stickylistheaders/TestActivity.java
+++ b/sample/src/se/emilsjolander/stickylistheaders/TestActivity.java
@@ -8,6 +8,7 @@ import android.support.v4.app.ActionBarDrawerToggle;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarActivity;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.*;
 
@@ -17,7 +18,7 @@ import android.widget.*;
 public class TestActivity extends ActionBarActivity implements
         AdapterView.OnItemClickListener, StickyListHeadersListView.OnHeaderClickListener,
         StickyListHeadersListView.OnStickyHeaderOffsetChangedListener,
-        StickyListHeadersListView.OnStickyHeaderChangedListener {
+        StickyListHeadersListView.OnStickyHeaderChangedListener, View.OnTouchListener {
 
     private TestBaseAdapter mAdapter;
     private DrawerLayout mDrawerLayout;
@@ -53,6 +54,7 @@ public class TestActivity extends ActionBarActivity implements
         stickyList.setDrawingListUnderStickyHeader(true);
         stickyList.setAreHeadersSticky(true);
         stickyList.setAdapter(mAdapter);
+        stickyList.setOnTouchListener(this);
 
         mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
         mDrawerToggle = new ActionBarDrawerToggle(
@@ -174,5 +176,12 @@ public class TestActivity extends ActionBarActivity implements
                                       int itemPosition, long headerId) {
         Toast.makeText(this, "Sticky Header Changed to " + headerId,
                 Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public boolean onTouch(View v, MotionEvent event) {
+        Toast.makeText(this, "OnTouch works", Toast.LENGTH_SHORT).show();
+        v.setOnTouchListener(null);
+        return false;
     }
 }


### PR DESCRIPTION
`StickyListHeadersListView` could not handle any touch events because all touch events are consumed by `ListView`.
I made a fix to `setOnTouchListener()` so that `OnTouchListener` can handle touch events as if it's attached to ListView.
