### PR TITLE
Draw divider for list header/footer views

### DIFF
--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -25,6 +25,8 @@
         <attr name="android:scrollbarStyle" />
         <attr name="android:divider" />
         <attr name="android:dividerHeight" />
+        <attr name="android:headerDividersEnabled" />
+        <attr name="android:footerDividersEnabled" />
 
         <!-- StickyListHeaders attributes -->
         <attr name="hasStickyHeaders" format="boolean" />

--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -123,6 +123,7 @@ public class StickyListHeadersListView extends FrameLayout {
         mDividerHeight = mList.getDividerHeight();
         mList.setDivider(null);
         mList.setDividerHeight(0);
+        mList.setListDivider(mDivider, mDividerHeight);
 
         if (attrs != null) {
             TypedArray a = context.getTheme().obtainStyledAttributes(attrs,R.styleable.StickyListHeadersListView, 0, 0);
@@ -198,6 +199,8 @@ public class StickyListHeadersListView extends FrameLayout {
 
                 mDividerHeight = a.getDimensionPixelSize(R.styleable.StickyListHeadersListView_android_dividerHeight,
                         mDividerHeight);
+
+                mList.setListDivider(mDivider, mDividerHeight);
 
                 // -- StickyListHeaders attributes --
                 mAreHeadersSticky = a.getBoolean(R.styleable.StickyListHeadersListView_hasStickyHeaders, true);
@@ -652,6 +655,7 @@ public class StickyListHeadersListView extends FrameLayout {
 
     public void setDivider(Drawable divider) {
         mDivider = divider;
+        mList.setListDivider(mDivider, mDividerHeight);
         if (mAdapter != null) {
             mAdapter.setDivider(mDivider, mDividerHeight);
         }
@@ -659,6 +663,7 @@ public class StickyListHeadersListView extends FrameLayout {
 
     public void setDividerHeight(int dividerHeight) {
         mDividerHeight = dividerHeight;
+        mList.setListDivider(mDivider, mDividerHeight);
         if (mAdapter != null) {
             mAdapter.setDivider(mDivider, mDividerHeight);
         }
@@ -716,6 +721,10 @@ public class StickyListHeadersListView extends FrameLayout {
 
     public void addFooterView(View v) {
         mList.addFooterView(v);
+    }
+
+    public void addFooterView(View v, Object data, boolean isSelectable) {
+        mList.addFooterView(v, data, isSelectable);
     }
 
     public void removeFooterView(View v) {

--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -202,6 +202,9 @@ public class StickyListHeadersListView extends FrameLayout {
 
                 mList.setListDivider(mDivider, mDividerHeight);
 
+                mList.setHeaderDividersEnabled(a.getBoolean(R.styleable.StickyListHeadersListView_android_headerDividersEnabled, true));
+                mList.setFooterDividersEnabled(a.getBoolean(R.styleable.StickyListHeadersListView_android_footerDividersEnabled, true));
+
                 // -- StickyListHeaders attributes --
                 mAreHeadersSticky = a.getBoolean(R.styleable.StickyListHeadersListView_hasStickyHeaders, true);
                 mIsDrawingListUnderStickyHeader = a.getBoolean(
@@ -675,6 +678,14 @@ public class StickyListHeadersListView extends FrameLayout {
 
     public int getDividerHeight() {
         return mDividerHeight;
+    }
+
+    public void setHeaderDividersEnabled(boolean headerDividersEnabled) {
+        mList.setHeaderDividersEnabled(headerDividersEnabled);
+    }
+
+    public void setFooterDividersEnabled(boolean footerDividersEnabled) {
+        mList.setFooterDividersEnabled(footerDividersEnabled);
     }
 
     public void setOnScrollListener(OnScrollListener onScrollListener) {

--- a/library/src/se/emilsjolander/stickylistheaders/WrapperView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/WrapperView.java
@@ -26,6 +26,12 @@ public class WrapperView extends ViewGroup {
 		super(c);
 	}
 
+	WrapperView(Context c, View item) {
+		super(c);
+
+		update(item, null, null, 0);
+	}
+
 	public boolean hasHeader() {
 		return mHeader != null;
 	}

--- a/library/src/se/emilsjolander/stickylistheaders/WrapperViewList.java
+++ b/library/src/se/emilsjolander/stickylistheaders/WrapperViewList.java
@@ -29,6 +29,9 @@ class WrapperViewList extends ListView {
 	private Drawable mDivider;
 	private int mDividerHeight;
 	private Rect mDividerTempRect = new Rect();
+	private boolean mHeaderDividersEnabled = true;
+	private boolean mFooterDividersEnabled = true;
+
 
 	public WrapperViewList(Context context) {
 		super(context);
@@ -110,7 +113,7 @@ class WrapperViewList extends ListView {
 		}
 
 		// bottom divider
-		if (mDivider != null && getChildCount() > 0) {
+		if (mFooterDividersEnabled && mDivider != null && getChildCount() > 0) {
 			int t = getChildAt(getChildCount() - 1).getBottom();
 
 			mDividerTempRect.set(mDivider.getBounds());
@@ -132,6 +135,22 @@ class WrapperViewList extends ListView {
 	}
 
 	@Override
+	public void setHeaderDividersEnabled(boolean headerDividersEnabled) {
+		super.setHeaderDividersEnabled(headerDividersEnabled);
+		this.mHeaderDividersEnabled = headerDividersEnabled;
+
+		updateHeaderViews();
+	}
+
+	@Override
+	public void setFooterDividersEnabled(boolean footerDividersEnabled) {
+		super.setFooterDividersEnabled(footerDividersEnabled);
+		this.mFooterDividersEnabled = footerDividersEnabled;
+
+		updateFooterViews();
+	}
+
+	@Override
 	public void addHeaderView(View v, Object data, boolean isSelectable) {
 		if (mHeaderWrapperViews == null) {
 			mHeaderWrapperViews = new ArrayList<WrapperView>();
@@ -147,7 +166,8 @@ class WrapperViewList extends ListView {
 	@Override
 	public boolean removeHeaderView(View v) {
 		WrapperView wv = getWrapperViewByItem(mHeaderWrapperViews, v);
-		if (super.removeHeaderView(wv)) {
+		if (wv != null) {
+			super.removeHeaderView(wv);
 			mHeaderWrapperViews.remove(wv);
 			updateHeaderViews();
 			return true;
@@ -158,7 +178,7 @@ class WrapperViewList extends ListView {
 	private void updateHeaderViews() {
 		for (int i = 0; i < getHeaderViewsCount(); i++) {
 			WrapperView wv = mHeaderWrapperViews.get(i);
-			if (i == 0) {
+			if (i == 0 || !mHeaderDividersEnabled) {
 				wv.update(wv.getItem(), null, null, 0);
 			} else {
 				wv.update(wv.getItem(), null, mDivider, mDividerHeight);
@@ -172,20 +192,34 @@ class WrapperViewList extends ListView {
 			mFooterWrapperViews = new ArrayList<WrapperView>();
 		}
 
-		WrapperView wv = new WrapperView(getContext());
-		wv.update(v, null, mDivider, mDividerHeight);
+		WrapperView wv = new WrapperView(getContext(), v);
 		super.addFooterView(wv, data, isSelectable);
 		mFooterWrapperViews.add(wv);
+
+        updateFooterViews();
 	}
 
 	@Override
 	public boolean removeFooterView(View v) {
 		WrapperView wv = getWrapperViewByItem(mFooterWrapperViews, v);
-		if (super.removeFooterView(wv)) {
+		if (wv != null) {
+			super.removeFooterView(wv);
 			mFooterWrapperViews.remove(wv);
+			// no need to update dividers
 			return true;
 		}
 		return false;
+	}
+
+	private void updateFooterViews() {
+		for (int i = 0; i < getFooterViewsCount(); i++) {
+			WrapperView wv = mFooterWrapperViews.get(i);
+			if (!mFooterDividersEnabled) {
+				wv.update(wv.getItem(), null, null, 0);
+			} else {
+				wv.update(wv.getItem(), null, mDivider, mDividerHeight);
+			}
+		}
 	}
 
 	static WrapperView getWrapperViewByItem(List<WrapperView> wrapperViewList, View item) {

--- a/sample/res/layout/list_footer.xml
+++ b/sample/res/layout/list_footer.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
-    
-    <TextView android:text="@string/app_name"
-    android:layout_width="match_parent"
-    android:layout_height="700dip"
-    android:gravity="center"
-    android:layout_gravity="center"/>
-    
+    android:layout_height="match_parent">
+
+    <TextView
+        android:text="@string/app_name"
+        android:layout_width="match_parent"
+        android:layout_height="350dip"
+        android:gravity="center"
+        android:layout_gravity="center" />
+
 
 </FrameLayout>

--- a/sample/res/layout/list_header.xml
+++ b/sample/res/layout/list_header.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
-    
-    <TextView android:text="@string/app_name"
-    android:layout_width="match_parent"
-    android:layout_height="400dip"
-    android:gravity="center"
-    android:layout_gravity="center"/>
-    
+    android:layout_height="match_parent">
+
+    <TextView
+        android:text="@string/app_name"
+        android:layout_width="match_parent"
+        android:layout_height="200dip"
+        android:gravity="center"
+        android:layout_gravity="center" />
+
 
 </FrameLayout>

--- a/sample/res/layout/main.xml
+++ b/sample/res/layout/main.xml
@@ -18,7 +18,9 @@
                 android:padding="16dp"
                 android:scrollbarStyle="outsideOverlay"
                 android:fastScrollEnabled="true"
-            android:overScrollMode="never"/>
+                android:headerDividersEnabled="false"
+                android:footerDividersEnabled="true"
+                android:overScrollMode="never"/>
 
         <TextView
                 android:id="@+id/empty"

--- a/sample/res/layout/main.xml
+++ b/sample/res/layout/main.xml
@@ -18,7 +18,7 @@
                 android:padding="16dp"
                 android:scrollbarStyle="outsideOverlay"
                 android:fastScrollEnabled="true"
-                android:headerDividersEnabled="false"
+                android:headerDividersEnabled="true"
                 android:footerDividersEnabled="true"
                 android:overScrollMode="never"/>
 
@@ -45,7 +45,7 @@
 
         <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:orientation="vertical">
 
             <se.emilsjolander.stickylistheaders.views.UnderlineTextView
@@ -111,6 +111,20 @@
                 android:layout_height="wrap_content"
                 android:text="@string/fast_scroll"
                 android:id="@+id/fast_scroll_checkBox"
+                android:checked="true"/>
+
+            <CheckBox
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/header_dividers"
+                android:id="@+id/header_dividers_checkBox"
+                android:checked="true"/>
+
+            <CheckBox
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/footer_dividers"
+                android:id="@+id/footer_dividers_checkBox"
                 android:checked="true"/>
         </LinearLayout>
     </ScrollView>

--- a/sample/res/values/strings.xml
+++ b/sample/res/values/strings.xml
@@ -16,5 +16,7 @@
     <string name="fade_header">Fade header</string>
     <string name="draw_behind_header">Draw behind header</string>
     <string name="fast_scroll">Fast scroll</string>
+    <string name="header_dividers">Header dividers</string>
+    <string name="footer_dividers">Footer dividers</string>
 
 </resources>

--- a/sample/src/se/emilsjolander/stickylistheaders/TestActivity.java
+++ b/sample/src/se/emilsjolander/stickylistheaders/TestActivity.java
@@ -48,8 +48,17 @@ public class TestActivity extends ActionBarActivity implements
         stickyList.setOnHeaderClickListener(this);
         stickyList.setOnStickyHeaderChangedListener(this);
         stickyList.setOnStickyHeaderOffsetChangedListener(this);
-        stickyList.addHeaderView(getLayoutInflater().inflate(R.layout.list_header, null));
-        stickyList.addFooterView(getLayoutInflater().inflate(R.layout.list_footer, null));
+
+        View headerView = getLayoutInflater().inflate(R.layout.list_header, null);
+        stickyList.addHeaderView(headerView);
+        stickyList.removeHeaderView(headerView);
+        stickyList.addHeaderView(headerView);
+
+        View footerView = getLayoutInflater().inflate(R.layout.list_footer, null);
+        stickyList.addFooterView(footerView);
+        stickyList.removeFooterView(footerView);
+        stickyList.addFooterView(footerView);
+
         stickyList.setEmptyView(findViewById(R.id.empty));
         stickyList.setDrawingListUnderStickyHeader(true);
         stickyList.setAreHeadersSticky(true);

--- a/sample/src/se/emilsjolander/stickylistheaders/TestActivity.java
+++ b/sample/src/se/emilsjolander/stickylistheaders/TestActivity.java
@@ -53,10 +53,14 @@ public class TestActivity extends ActionBarActivity implements
         stickyList.addHeaderView(headerView);
         stickyList.removeHeaderView(headerView);
         stickyList.addHeaderView(headerView);
+        headerView = getLayoutInflater().inflate(R.layout.list_header, null);
+        stickyList.addHeaderView(headerView);
 
         View footerView = getLayoutInflater().inflate(R.layout.list_footer, null);
         stickyList.addFooterView(footerView);
         stickyList.removeFooterView(footerView);
+        stickyList.addFooterView(footerView);
+        footerView = getLayoutInflater().inflate(R.layout.list_footer, null);
         stickyList.addFooterView(footerView);
 
         stickyList.setEmptyView(findViewById(R.id.empty));

--- a/sample/src/se/emilsjolander/stickylistheaders/TestActivity.java
+++ b/sample/src/se/emilsjolander/stickylistheaders/TestActivity.java
@@ -35,6 +35,8 @@ public class TestActivity extends ActionBarActivity implements
     private CheckBox fadeCheckBox;
     private CheckBox drawBehindCheckBox;
     private CheckBox fastScrollCheckBox;
+    private CheckBox headerDividersCheckBox;
+    private CheckBox footerDividersCheckBox;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -99,6 +101,10 @@ public class TestActivity extends ActionBarActivity implements
         drawBehindCheckBox.setOnCheckedChangeListener(checkBoxListener);
         fastScrollCheckBox = (CheckBox) findViewById(R.id.fast_scroll_checkBox);
         fastScrollCheckBox.setOnCheckedChangeListener(checkBoxListener);
+        headerDividersCheckBox = (CheckBox) findViewById(R.id.header_dividers_checkBox);
+        headerDividersCheckBox.setOnCheckedChangeListener(checkBoxListener);
+        footerDividersCheckBox = (CheckBox) findViewById(R.id.footer_dividers_checkBox);
+        footerDividersCheckBox.setOnCheckedChangeListener(checkBoxListener);
     }
 
     @Override
@@ -140,6 +146,12 @@ public class TestActivity extends ActionBarActivity implements
                 case R.id.fast_scroll_checkBox:
                     stickyList.setFastScrollEnabled(isChecked);
                     stickyList.setFastScrollAlwaysVisible(isChecked);
+                    break;
+                case R.id.header_dividers_checkBox:
+                    stickyList.setHeaderDividersEnabled(isChecked);
+                    break;
+                case R.id.footer_dividers_checkBox:
+                    stickyList.setFooterDividersEnabled(isChecked);
                     break;
             }
         }


### PR DESCRIPTION
Dividers for header/footer view is drawn in `ListView` by default. I made a patch to imitate this drawing using pattern already being used in the library; making use of `WrapperView`. Header/footer view is now wrapped by `WrapperView` and managed with a little more care.

_WrapperViewList.java:112-121_
As each divider in `WrapperView` is drawn by the view below, the last divider at the bottom has to be drawn differently. (fyi: divider at the bottom is only shown when items of the `ListView` doesn't fill all the `ListView`'s space. Refer to the screenshots in [this SO question](http://stackoverflow.com/questions/14199274/separator-divider-after-last-item-of-listview))

Further improvement would be to implement `android:header(footer)dividersenabled`, giving on/off functionality.

If you would merge please review the code throughly. Though I tested several cases I may have not caught all the edge cases. I'd be glad to take any feedback.
