### PR TITLE
Prevent drawing listview when it's not visible

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -267,8 +267,9 @@ public class StickyListHeadersListView extends FrameLayout {
         // The header should be drawn right after the lists children are drawn.
         // This is done so that the header is above the list items
         // but below the list decorators (scroll bars etc).
-        if (mList.getVisibility() == VISIBLE || mList.getAnimation() != null)
+        if (mList.getVisibility() == VISIBLE || mList.getAnimation() != null) {
             drawChild(canvas, mList, 0);
+        }
     }
 
     // Reset values tied the header. also remove header form layout


### PR DESCRIPTION
In `dispatchDraw()` method viewgroup is responsible for checking its child's visibility, drawing only if the child is visible. Please see [ViewGroup.java:2939](https://github.com/android/platform_frameworks_base/blob/77e9a28e2faa36f127231b842476d47f9823a83a/core/java/android/view/ViewGroup.java#L2939)

Not checking the child(ListView) visibility from `StickyListHeadersView` produces a bug which causes header/footer views to be drawn when adapter flushes its data.
I caught this bug with Android 4.3(18) but might be reproducible with any version except Kitkat.

![screenshot 2014-02-20 01 07 07](https://f.cloud.github.com/assets/1078489/2208452/2f49d382-9980-11e3-8080-a9c236ff22d1.png)
