### PR TITLE
Remove redundant modifiers in interface method declarations

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/AdapterWrapper.java
+++ b/library/src/se/emilsjolander/stickylistheaders/AdapterWrapper.java
@@ -26,7 +26,7 @@ import android.widget.ListAdapter;
 class AdapterWrapper extends BaseAdapter implements StickyListHeadersAdapter {
 
 	interface OnHeaderClickListener {
-		public void onHeaderClick(View header, int itemPosition, long headerId);
+		void onHeaderClick(View header, int itemPosition, long headerId);
 	}
 
 	final StickyListHeadersAdapter mDelegate;

--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -37,7 +37,7 @@ import se.emilsjolander.stickylistheaders.WrapperViewList.LifeCycleListener;
 public class StickyListHeadersListView extends FrameLayout {
 
     public interface OnHeaderClickListener {
-        public void onHeaderClick(StickyListHeadersListView l, View header,
+        void onHeaderClick(StickyListHeadersListView l, View header,
                                   int itemPosition, long headerId, boolean currentlySticky);
     }
 
@@ -54,7 +54,7 @@ public class StickyListHeadersListView extends FrameLayout {
          *               get* methods for determining the view's size.
          * @param offset The amount the sticky header is offset by towards to top of the screen.
          */
-        public void onStickyHeaderOffsetChanged(StickyListHeadersListView l, View header, int offset);
+        void onStickyHeaderOffsetChanged(StickyListHeadersListView l, View header, int offset);
     }
 
     /**
@@ -68,7 +68,7 @@ public class StickyListHeadersListView extends FrameLayout {
          *                      the item whose header is now sticky.
          * @param headerId      The id of the new sticky header.
          */
-        public void onStickyHeaderChanged(StickyListHeadersListView l, View header,
+        void onStickyHeaderChanged(StickyListHeadersListView l, View header,
                                           int itemPosition, long headerId);
 
     }


### PR DESCRIPTION
As per JLS it is discouraged to specify the public modifier for methods
declared in an interface. This commit also makes sure that the behavior is
consistent across code files.
