### PR TITLE
obvious fix for header click handler

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -596,19 +596,20 @@ public class StickyListHeadersListView extends FrameLayout {
         if (mAdapter != null) {
             if (mOnHeaderClickListener != null) {
                 mAdapter.setOnHeaderClickListener(new AdapterWrapperHeaderClickHandler());
+
+                if (mHeader != null) {
+                    mHeader.setOnClickListener(new OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            mOnHeaderClickListener.onHeaderClick(
+                                    StickyListHeadersListView.this, mHeader,
+                                    mHeaderPosition, mHeaderId, true);
+                        }
+                    });
+                }
             } else {
                 mAdapter.setOnHeaderClickListener(null);
             }
-        }
-        if (mHeader != null && mOnHeaderClickListener != null) {
-            mHeader.setOnClickListener(new OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    mOnHeaderClickListener.onHeaderClick(
-                            StickyListHeadersListView.this, mHeader,
-                            mHeaderPosition, mHeaderId, true);
-                }
-            });
         }
     }
 


### PR DESCRIPTION
if user do not provide "OnHeaderClickListener", the header view will not be clickable,
so user will be able to "get" to the underlying views and handle clicks by himself
