### PR TITLE
AddFooter(View, Object, boolean) is updated to add the view to the inter...

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/WrapperViewList.java
+++ b/library/src/se/emilsjolander/stickylistheaders/WrapperViewList.java
@@ -72,7 +72,7 @@ class WrapperViewList extends ListView {
 
 	private int getSelectorPosition() {
 		if (mSelectorPositionField == null) { // not all supported andorid
-												// version have this variable
+			// version have this variable
 			for (int i = 0; i < getChildCount(); i++) {
 				if (getChildAt(i).getBottom() == mSelectorRect.bottom) {
 					return i + getFixedFirstVisibleItem();
@@ -113,6 +113,16 @@ class WrapperViewList extends ListView {
 	@Override
 	public void addFooterView(View v) {
 		super.addFooterView(v);
+		addInternalFooterView(v);
+	}
+
+	@Override
+	public void addFooterView(View v, Object data, boolean isSelectable) {
+		super.addFooterView(v, data, isSelectable);
+		addInternalFooterView(v);
+	}
+
+	private void addInternalFooterView(View v) {
 		if (mFooterViews == null) {
 			mFooterViews = new ArrayList<View>();
 		}


### PR DESCRIPTION
Had a test case like,

StickyListHeaderListView listView;
listView.addFooterView(footerView, myFooterData, true);

....
if (listView.containsFooterView(footerView)) {
   listView.removeFooterView(footerView);
}

// or worse
listView.removeFooterView(footerView); // Crashes since WrapperList.mFooterViews is null.

WrapperList.removeFooter assumes the mFooterViews list is non null, except that addFooterView(View, Object, boolean) was not overridden to update mFooterViews list. This just makes the implementation more consistent. 
