### PR TITLE
Header Views Incorrectly Hide on Lists with Multiple Headers

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -294,8 +294,8 @@ public class StickyListHeadersListView extends FrameLayout {
             return;
         }
 
-        final int headerViewCount = mList.getHeaderViewsCount();
-        int headerPosition = firstVisiblePosition - headerViewCount;
+        final boolean hasHeaders = mList.getHeaderViewsCount() > 0;
+        int headerPosition = firstVisiblePosition - (hasHeaders ? 1 : 0);
         if (mList.getChildCount() > 0) {
             View firstItem = mList.getChildAt(0);
             if (firstItem.getBottom() < stickyHeaderTop()) {


### PR DESCRIPTION
Resolve issue where lists with multiple header views would incorrectly hide the first sticky header when scrolling back up to the top of the list.

The issue appeared to be that the code was looking to detect if the list header view was below the sticky header, but the check was looking for just the first child in the list which could be one of many headers (since listview removes them from the layout).

This fix makes the check to see if simply there is a header view to account for, and, if it's still behind the sticky header, maintain the headerPosition logic.
