### PR TITLE
Memory leak problem with DataSetObserver

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -1077,4 +1077,23 @@ public class StickyListHeadersListView extends FrameLayout {
         mList.setBlockLayoutChildren(blockLayoutChildren);
     }
 
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if (mAdapter != null) {
+            if (mDataSetObserver != null) {
+                mDataSetObserver = new AdapterWrapperDataSetObserver();
+            }
+            mAdapter.registerDataSetObserver(mDataSetObserver);
+        }
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        if (mAdapter != null && mDataSetObserver != null) {
+            mAdapter.unregisterDataSetObserver(mDataSetObserver);
+        }
+        super.onDetachedFromWindow();
+    }
+
 }


### PR DESCRIPTION
There is a memory leak when listview is not visible but DataSetObserver still in memory.
My app has four tabs , one of them contains a StickyListHeadersListView, I found that everytime I switch to this other tab and switch back, the memory inscreases, so I look into MAT, found the DataSetObserver in StickyListHeadersListView are holding all my list items, so I think we should unregister this when listview are detached from window.