### PR TITLE
Dynamically show/hide headers without changing the adapter

### DIFF
--- a/library/src/se/emilsjolander/stickylistheaders/AdapterWrapper.java
+++ b/library/src/se/emilsjolander/stickylistheaders/AdapterWrapper.java
@@ -163,18 +163,21 @@ class AdapterWrapper extends BaseAdapter implements StickyListHeadersAdapter {
 		WrapperView wv = (convertView == null) ? new WrapperView(mContext) : (WrapperView) convertView;
 		View item = mDelegate.getView(position, wv.mItem, parent);
 		View header = null;
-		if (previousPositionHasSameHeader(position)) {
-			recycleHeaderIfExists(wv);
-		} else {
-			header = configureHeader(wv, position);
-		}
-		if((item instanceof Checkable) && !(wv instanceof CheckableWrapperView)) {
-			// Need to create Checkable subclass of WrapperView for ListView to work correctly
-			wv = new CheckableWrapperView(mContext);
-		} else if(!(item instanceof Checkable) && (wv instanceof CheckableWrapperView)) {
-			wv = new WrapperView(mContext);
+		if (mDelegate.shouldShowHeaders()) {
+			if (previousPositionHasSameHeader(position)) {
+				recycleHeaderIfExists(wv);
+			} else {
+				header = configureHeader(wv, position);
+			}
+			if((item instanceof Checkable) && !(wv instanceof CheckableWrapperView)) {
+				// Need to create Checkable subclass of WrapperView for ListView to work correctly
+				wv = new CheckableWrapperView(mContext);
+			} else if(!(item instanceof Checkable) && (wv instanceof CheckableWrapperView)) {
+				wv = new WrapperView(mContext);
+			}
 		}
 		wv.update(item, header, mDivider, mDividerHeight);
+
 		return wv;
 	}
 
@@ -220,6 +223,11 @@ class AdapterWrapper extends BaseAdapter implements StickyListHeadersAdapter {
 	@Override
 	public long getHeaderId(int position) {
 		return mDelegate.getHeaderId(position);
+	}
+
+	@Override
+	public boolean shouldShowHeaders() {
+		return mDelegate.shouldShowHeaders();
 	}
 
 }

--- a/library/src/se/emilsjolander/stickylistheaders/ExpandableStickyListHeadersAdapter.java
+++ b/library/src/se/emilsjolander/stickylistheaders/ExpandableStickyListHeadersAdapter.java
@@ -34,6 +34,11 @@ import java.util.List;
     }
 
     @Override
+    public boolean shouldShowHeaders() {
+        return mInnerAdapter.shouldShowHeaders();
+    }
+
+    @Override
     public boolean areAllItemsEnabled() {
         return mInnerAdapter.areAllItemsEnabled();
     }

--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersAdapter.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersAdapter.java
@@ -35,4 +35,12 @@ public interface StickyListHeadersAdapter extends ListAdapter {
 	 * The id of the header at the specified position.
 	 */
 	long getHeaderId(int position);
+
+	/**
+	 * Check whether or not the adapter should display header views.
+	 * 
+         * @return
+	 * If false, no headers will be displayed.
+         */
+	boolean shouldShowHeaders();
 }

--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersAdapter.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersAdapter.java
@@ -39,8 +39,8 @@ public interface StickyListHeadersAdapter extends ListAdapter {
 	/**
 	 * Check whether or not the adapter should display header views.
 	 * 
-         * @return
+	 * @return
 	 * If false, no headers will be displayed.
-         */
+	 */
 	boolean shouldShowHeaders();
 }

--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -509,7 +509,10 @@ public class StickyListHeadersListView extends FrameLayout {
                 mOnScrollListenerDelegate.onScroll(view, firstVisibleItem,
                         visibleItemCount, totalItemCount);
             }
-            updateOrClearHeader(mList.getFixedFirstVisibleItem());
+
+            if (mAdapter != null && mAdapter.shouldShowHeaders()) {
+                updateOrClearHeader(mList.getFixedFirstVisibleItem());
+            }
         }
 
         @Override


### PR DESCRIPTION
There's another PR for this feature. IMHO, the problem with that solution is that it resets the adapter every time you change the flag and that's not ideal in many cases (i.e. repopulate everything, set origin to 0, etc...).
My approach handles this problem on the adapter level by creating a new method on the interface that will be consumed from custom or built-in adapters by implementing `shouldShowHeaders` which can dynamically change its value.
