### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the following maven dependency exchanging `x.x.x` for the latest release.
 Add the following gradle dependency exchanging `x.x.x` for the latest release.
 ```groovy
 dependencies {
-    compile 'se.emilsjolander:stickylistheaders:x.x.x'
+    implementation 'se.emilsjolander:stickylistheaders:x.x.x'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.